### PR TITLE
Add Korean translation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Lox is a lexer and parser generator for Go.
 
 For comprehensive documentation, examples, and tutorials, visit **[dcaiafa.github.io/lox](https://dcaiafa.github.io/lox/)**.
 
+### Community translation
+
+- [한국어 (Korean)](https://ybkimm.github.io/lox-kr-docs)
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Hi!

I've translated the documentation into Korean and would like to add a link to help Korean developers find it.

The translation is hosted at: https://ybkimm.github.io/lox-kr-docs ([GitHub Repository](https://github.com/ybkimm/lox-kr-docs))

Thanks for the great project!